### PR TITLE
Fixed minor translation issue.

### DIFF
--- a/docs/cpp/results-of-calling-example.md
+++ b/docs/cpp/results-of-calling-example.md
@@ -36,13 +36,13 @@ ms.lasthandoff: 12/21/2017
 __cdecl の呼び出し規則  
   
 ## <a name="stdcall-and-thiscall"></a>__stdcall と thiscall  
- C の装飾名 (`__stdcall`) は"_MyFunc@20"。 C++ の装飾名は商標で守られています。  
+ C の装飾名 (`__stdcall`) は "_MyFunc@20" です。 C++ の装飾名は処理系固有の仕様です。  
   
  ![&#95; &#95; stdcall と thiscall の呼び出し規約](../cpp/media/vc37i02.gif "vc37I02")  
 __stdcall と thiscall の呼び出し規則  
   
 ## <a name="fastcall"></a>__fastcall  
- C の装飾名 (`__fastcall`) は"@MyFunc@20"。 C++ の装飾名は商標で守られています。  
+ C の装飾名 (`__fastcall`) は "@MyFunc@20" です。 C++ の装飾名は処理系固有の仕様です。  
   
  ![呼び出し規約 &#95; &#95; fastcall](../cpp/media/vc37i03.gif "vc37I03")  
 __fastcall の呼び出し規則  


### PR DESCRIPTION
The word "proprietary" means "VC++ specific feature", not "trademark."