### PR TITLE
String::isempty explanation in Japanese is wrong

### DIFF
--- a/docs/cppcx/platform-string-class.md
+++ b/docs/cppcx/platform-string-class.md
@@ -270,7 +270,7 @@ bool IsEmpty()
 ```  
   
 ### <a name="return-value"></a>戻り値  
- 現在の String オブジェクトが `true` または空の文字列 ("") の場合は `null`。それ以外の場合は `false`。  
+ 現在の String オブジェクトが `null` または空の文字列 ("") の場合は `true`。それ以外の場合は `false`。  
   
 
 


### PR DESCRIPTION
Original sentence said 'null if the current String object is true or the empty string (L""); otherwise, false.' in Japanese. So just replaced the position of "true" and "null".