### PR TITLE
準拠している → conform

### DIFF
--- a/docs/preprocessor/pragma-directives-and-the-pragma-keyword.md
+++ b/docs/preprocessor/pragma-directives-and-the-pragma-keyword.md
@@ -47,8 +47,8 @@ Microsoft C および C++ コンパイラは、次のプラグマを認識しま
 |-|-|-|
 |[alloc_text](../preprocessor/alloc-text.md)|[auto_inline](../preprocessor/auto-inline.md)|[bss_seg](../preprocessor/bss-seg.md)|
 |[check_stack](../preprocessor/check-stack.md)|[code_seg](../preprocessor/code-seg.md)|[comment](../preprocessor/comment-c-cpp.md)|
-|[component](../preprocessor/component.md)|[準拠している](../preprocessor/conform.md) <sup>1</sup>|[const_seg](../preprocessor/const-seg.md)|
-|[data_seg](../preprocessor/data-seg.md)|[非推奨](../preprocessor/deprecated-c-cpp.md)|[detect_mismatch](../preprocessor/detect-mismatch.md)|
+|[component](../preprocessor/component.md)|[conform](../preprocessor/conform.md) <sup>1</sup>|[const_seg](../preprocessor/const-seg.md)|
+|[data_seg](../preprocessor/data-seg.md)|[deprecated](../preprocessor/deprecated-c-cpp.md)|[detect_mismatch](../preprocessor/detect-mismatch.md)|
 |[fenv_access](../preprocessor/fenv-access.md)|[float_control](../preprocessor/float-control.md)|[fp_contract](../preprocessor/fp-contract.md)|
 |[function](../preprocessor/function-c-cpp.md)|[hdrstop](../preprocessor/hdrstop.md)|[include_alias](../preprocessor/include-alias.md)|
 |[init_seg](../preprocessor/init-seg.md) <sup>1</sup>|[inline_depth](../preprocessor/inline-depth.md)|[inline_recursion](../preprocessor/inline-recursion.md)|


### PR DESCRIPTION
準拠している → conform
非推奨 → deprecated

https://docs.microsoft.com/ja-jp/cpp/preprocessor/pragma-directives-and-the-pragma-keyword?view=vs-2017

[conform](https://docs.microsoft.com/ja-jp/cpp/preprocessor/conform)
[deprecated (C/C++)](https://docs.microsoft.com/ja-jp/cpp/preprocessor/deprecated-c-cpp)