### PR TITLE
fix "例外。キャッチと削除例外"→"例外:キャッチと削除例外"

### DIFF
--- a/docs/mfc/exceptions-using-mfc-macros-and-cpp-exceptions.md
+++ b/docs/mfc/exceptions-using-mfc-macros-and-cpp-exceptions.md
@@ -35,7 +35,7 @@ ms.locfileid: "62406016"
 
 ##  <a name="_core_mixing_exception_keywords_and_macros"></a> 例外のキーワードとマクロの混在
 
-MFC 例外マクロと同じプログラム内での C++ 例外のキーワードを混在させることができます。 ただし、マクロは、例外オブジェクトを自動的に削除、有効範囲外に出ると、例外処理キーワードを使用して、コードは実行されませんので、同じブロック内の C++ 例外のキーワードを持つ MFC マクロを混ぜることはできません。 詳細については、[例外:キャッチと削除例外](../mfc/exceptions-catching-and-deleting-exceptions.md)を参照してください。
+MFC 例外マクロと C++ 例外のキーワードを同じプログラムに混在させることができます。 ただし、同じブロック内で　MFC　マクロと　C ++　例外キーワードを混在させることはできません。例外処理キーワードを使用したコードでは削除されないのに対し、マクロは例外オブジェクトを自動的に削除するためです。詳細については、[例外: 例外のキャッチと削除](../mfc/exceptions-catching-and-deleting-exceptions.md) を参照してください。
 
 マクロとキーワードの主な違いでは、例外がスコープ外になる、マクロがそのキャッチされた例外を「自動的に」削除することです。 キーワードを使用してコードを削除しません。catch ブロックでキャッチされた例外を明示的に削除する必要があります。 マクロと C++ 例外のキーワードまたは、メモリ リークが発生する例外オブジェクトを削除できなかった場合、ヒープの破損、例外が 2 回削除されるとします。
 
@@ -43,13 +43,13 @@ MFC 例外マクロと同じプログラム内での C++ 例外のキーワー�
 
 [!code-cpp[NVC_MFCExceptions#10](../mfc/codesnippet/cpp/exceptions-using-mfc-macros-and-cpp-exceptions_1.cpp)]
 
-問題は、 `e` 「内部」から実行が成功したときに削除**CATCH**ブロックします。 使用して、 **THROW_LAST**マクロの代わりに、**THROW**ステートメントが発生、「外部」**CATCH **ブロックが有効なポインターを受け取る。
+MFC 例外マクロと C++ 例外のキーワードを同じプログラムに混在させることができます。 ただし、同じブロック内で　MFC　マクロと　C ++　例外キーワードを混在させることはできません。例外処理キーワードを使用したコードでは削除されないのに対し、マクロは例外オブジェクトを自動的に削除するためです。詳細については、[例外: 例外のキャッチと削除](../mfc/exceptions-catching-and-deleting-exceptions.md) を参照してください。
 
 [!code-cpp[NVC_MFCExceptions#11](../mfc/codesnippet/cpp/exceptions-using-mfc-macros-and-cpp-exceptions_2.cpp)]
 
 ##  <a name="_core_try_blocks_inside_catch_blocks"></a> Try Catch ブロック内でのブロック
 
-内から現在の例外を再スローすることはできません、**try**ブロック内にある、**CATCH**ブロックします。 次の例では、有効です。
+**CATCH** ブロック内の **try** ブロック内から現在の例外を再スローすることはできません。次の例は無効です。
 
 [!code-cpp[NVC_MFCExceptions#12](../mfc/codesnippet/cpp/exceptions-using-mfc-macros-and-cpp-exceptions_3.cpp)]
 

--- a/docs/mfc/exceptions-using-mfc-macros-and-cpp-exceptions.md
+++ b/docs/mfc/exceptions-using-mfc-macros-and-cpp-exceptions.md
@@ -1,5 +1,5 @@
 ---
-title: 例外:MFC マクロと C++ 例外を使用します。
+title: 例外:MFC マクロと C++ 例外の使用
 ms.date: 11/04/2016
 helpviewer_keywords:
 - exception objects [MFC]
@@ -23,7 +23,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 04/23/2019
 ms.locfileid: "62406016"
 ---
-# <a name="exceptions-using-mfc-macros-and-c-exceptions"></a>例外:MFC マクロと C++ 例外を使用します。
+# <a name="exceptions-using-mfc-macros-and-c-exceptions"></a>例外:MFC マクロと C++ 例外の使用
 
 この記事では、MFC の例外処理マクロと C++ 例外処理のキーワードの両方を使用するコードの記述に関する考慮事項について説明します。
 
@@ -35,7 +35,7 @@ ms.locfileid: "62406016"
 
 ##  <a name="_core_mixing_exception_keywords_and_macros"></a> 例外のキーワードとマクロの混在
 
-MFC 例外マクロと同じプログラム内での C++ 例外のキーワードを混在させることができます。 ただし、マクロは、例外オブジェクトを自動的に削除、有効範囲外に出ると、例外処理キーワードを使用して、コードは実行されませんので、同じブロック内の C++ 例外のキーワードを持つ MFC マクロを混ぜることはできません。 詳細については、この記事を参照してください。[例外。キャッチと削除例外](../mfc/exceptions-catching-and-deleting-exceptions.md)します。
+MFC 例外マクロと同じプログラム内での C++ 例外のキーワードを混在させることができます。 ただし、マクロは、例外オブジェクトを自動的に削除、有効範囲外に出ると、例外処理キーワードを使用して、コードは実行されませんので、同じブロック内の C++ 例外のキーワードを持つ MFC マクロを混ぜることはできません。 詳細については、[例外:キャッチと削除例外](../mfc/exceptions-catching-and-deleting-exceptions.md)を参照してください。
 
 マクロとキーワードの主な違いでは、例外がスコープ外になる、マクロがそのキャッチされた例外を「自動的に」削除することです。 キーワードを使用してコードを削除しません。catch ブロックでキャッチされた例外を明示的に削除する必要があります。 マクロと C++ 例外のキーワードまたは、メモリ リークが発生する例外オブジェクトを削除できなかった場合、ヒープの破損、例外が 2 回削除されるとします。
 
@@ -43,17 +43,17 @@ MFC 例外マクロと同じプログラム内での C++ 例外のキーワー�
 
 [!code-cpp[NVC_MFCExceptions#10](../mfc/codesnippet/cpp/exceptions-using-mfc-macros-and-cpp-exceptions_1.cpp)]
 
-問題は、 `e` 「内部」から実行が成功したときに削除**キャッチ**ブロックします。 使用して、 **THROW_LAST**マクロの代わりに、**スロー**ステートメントが発生、「外部」**キャッチ**ブロックが有効なポインターを受け取る。
+問題は、 `e` 「内部」から実行が成功したときに削除**CATCH**ブロックします。 使用して、 **THROW_LAST**マクロの代わりに、**THROW**ステートメントが発生、「外部」**CATCH **ブロックが有効なポインターを受け取る。
 
 [!code-cpp[NVC_MFCExceptions#11](../mfc/codesnippet/cpp/exceptions-using-mfc-macros-and-cpp-exceptions_2.cpp)]
 
 ##  <a name="_core_try_blocks_inside_catch_blocks"></a> Try Catch ブロック内でのブロック
 
-内から現在の例外を再スローすることはできません、**お試しください**ブロック内にある、**キャッチ**ブロックします。 次の例では、有効です。
+内から現在の例外を再スローすることはできません、**try**ブロック内にある、**CATCH**ブロックします。 次の例では、有効です。
 
 [!code-cpp[NVC_MFCExceptions#12](../mfc/codesnippet/cpp/exceptions-using-mfc-macros-and-cpp-exceptions_3.cpp)]
 
-詳細については、次を参照してください。[例外。例外の内容の調査](../mfc/exceptions-examining-exception-contents.md)します。
+詳細については、[例外:例外の内容の調査](../mfc/exceptions-examining-exception-contents.md)を参照してください。
 
 ## <a name="see-also"></a>関連項目
 


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/cpp/mfc/exceptions-using-mfc-macros-and-cpp-exceptions?view=vs-2019