### PR TITLE
[LOC] Back-Translation "キャッチ"→"catch"

### DIFF
--- a/docs/mfc/exceptions-changes-to-exception-macros-in-version-3-0.md
+++ b/docs/mfc/exceptions-changes-to-exception-macros-in-version-3-0.md
@@ -28,17 +28,17 @@ Mfc バージョン 3.0 以降では、例外処理マクロが C++ 例外を使
 
 ##  <a name="_core_exception_types_and_the_catch_macro"></a> 例外の種類と、CATCH マクロ
 
-MFC の以前のバージョンで、**キャッチ**マクロでは、MFC の実行時の型情報を使用例外の種類を確認するには例外の型が決定されます、つまり、キャッチ側でします。 C++ の例外を除き、ただし、例外の型は常にスロー サイトによって決まりますスローされる例外オブジェクトの型。 スローされたオブジェクトへのポインターの型がスローされたオブジェクトの種類を異なる場所まれなケースで互換性が失われます。
+MFC の以前のバージョンで、**CATCH**マクロでは、MFC の実行時の型情報を使用例外の種類を確認するには例外の型が決定されます、つまり、キャッチ側でします。 C++ の例外を除き、ただし、例外の型は常にスロー サイトによって決まりますスローされる例外オブジェクトの型。 スローされたオブジェクトへのポインターの型がスローされたオブジェクトの種類を異なる場所まれなケースで互換性が失われます。
 
 次の例は、MFC バージョン 3.0 と以前のバージョンの間には、この違いの結果を示しています。
 
 [!code-cpp[NVC_MFCExceptions#1](../mfc/codesnippet/cpp/exceptions-changes-to-exception-macros-in-version-3-0_1.cpp)]
 
-このコードはバージョン 3.0 で異なる動作制御が常に最初に渡されるため、**キャッチ**と一致する例外-宣言ブロックします。 スロー式の結果
+このコードはバージョン 3.0 で異なる動作制御が常に最初に渡されるため、**catch**と一致する例外-宣言ブロックします。 スロー式の結果
 
 [!code-cpp[NVC_MFCExceptions#19](../mfc/codesnippet/cpp/exceptions-changes-to-exception-macros-in-version-3-0_2.cpp)]
 
-としてスローされる、`CException*`として構築した場合でも、`CCustomException`します。 **キャッチ**以前使用して MFC バージョン 2.5 マクロ`CObject::IsKindOf`実行時に、型をテストします。 式
+としてスローされる、`CException*`として構築した場合でも、`CCustomException`します。 **CATCH**以前使用して MFC バージョン 2.5 マクロ`CObject::IsKindOf`実行時に、型をテストします。 式
 
 [!code-cpp[NVC_MFCExceptions#20](../mfc/codesnippet/cpp/exceptions-changes-to-exception-macros-in-version-3-0_3.cpp)]
 
@@ -56,9 +56,9 @@ Catch ブロックでは、その例外はキャッチ例外ポインターと�
 
 [!code-cpp[NVC_MFCExceptions#2](../mfc/codesnippet/cpp/exceptions-changes-to-exception-macros-in-version-3-0_4.cpp)]
 
-使用して**スロー** catch ブロックが、ポインター`e`外側の catch のサイトは無効なポインターを受け取れるように、削除します。 使用**THROW_LAST**再スローする`e`します。
+使用して**THROW** catch ブロックが、ポインター`e`外側の catch のサイトは無効なポインターを受け取れるように、削除します。 使用**THROW_LAST**再スローする`e`します。
 
-詳細については、次を参照してください。[例外。キャッチと削除例外](../mfc/exceptions-catching-and-deleting-exceptions.md)します。
+詳細については、次を参照してください。[例外:キャッチと削除例外](../mfc/exceptions-catching-and-deleting-exceptions.md)します。
 
 ## <a name="see-also"></a>関連項目
 


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/cpp/mfc/exceptions-changes-to-exception-macros-in-version-3-0?view=vs-2019