### PR TITLE
[LOC] Back-Translation "および"→"and"

### DIFF
--- a/docs/c-runtime-library/reference/crt-alphabetical-function-reference.md
+++ b/docs/c-runtime-library/reference/crt-alphabetical-function-reference.md
@@ -77,7 +77,7 @@ ms.locfileid: "62340340"
 
 [_amsg_exit](amsg-exit.md)
 
-[および](and.md)
+[and](and.md)
 
 [and_eq](and-eq.md)
 
@@ -1215,7 +1215,7 @@ ms.locfileid: "62340340"
 
 [_isleadbyte_l](isleadbyte-isleadbyte-l.md)
 
-[小さければ](floating-point-ordering.md)
+[isless](floating-point-ordering.md)
 
 [islessequal](floating-point-ordering.md)
 


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/cpp/c-runtime-library/reference/crt-alphabetical-function-reference?view=vs-2019