### PR TITLE
Typo "_ _finally"→"__finally"

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2494.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2494.md
@@ -36,6 +36,7 @@ int main() {
 ```
 
 C2494 は、**/clr** を使用しているときも発生します。
+
 ```
 // C2494b.cpp
 // compile with: /clr

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2494.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2494.md
@@ -15,11 +15,11 @@ ms.locfileid: "62361647"
 ---
 # <a name="compiler-error-c2494"></a>コンパイラ エラー C2494
 
-'keyword' は、フィルター式内から呼び出すことはできませんまたは _ _finally/finally にブロック
+'keyword' は、フィルタ式または __finally/finally ブロック内から呼び出せません
 
-使用することはできません`keyword`で、`__finally`または finally ブロックします。
+`__finally`ブロックまたは finally ブロックの内部で、`keyword` は使用できません。
 
-次の例では、C2494 が生成されます。
+次の例では、C2494 エラーが生成されます。
 
 ```
 // C2494.cpp
@@ -35,8 +35,7 @@ int main() {
 }
 ```
 
-C2494 を使用する場合にも発生することが **/clr**します。
-
+C2494 は、**/clr** を使用しているときも発生します。
 ```
 // C2494b.cpp
 // compile with: /clr


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/cpp/error-messages/compiler-errors-1/compiler-error-c2494?view=vs-2019