### PR TITLE
起動と終了 (C++) ページ

### DIFF
--- a/docs/cpp/startup-and-termination-cpp.md
+++ b/docs/cpp/startup-and-termination-cpp.md
@@ -11,7 +11,7 @@ ms.locfileid: "62330819"
 ---
 # <a name="startup-and-termination-c"></a>起動と終了 (C++)
 
-プログラムの起動と終了は 2 つの関数を使用して容易になります:[メイン](../cpp/main-program-startup.md)と[終了](../cpp/program-termination.md)します。 他の開始コードと終了コードを実行することもできます。
+プログラムの起動と終了は次の2つの関数で容易に行えます: [main](../cpp/main-program-startup.md) と [exit](../cpp/program-termination.md)。他の開始と終了コードを実行させることもできます。
 
 ## <a name="see-also"></a>関連項目
 


### PR DESCRIPTION
関数名が日本語に翻訳されないように修正しました。

文体の調整も行いました。が、1つ目の文は原文を自然な形で日本語に訳すのが難しいです。。

英語の原文
```
Program startup and termination are facilitated by using two functions
```

