### PR TITLE
Typo "C/c + +"→"C/C++"

### DIFF
--- a/docs/preprocessor/hash-if-hash-elif-hash-else-and-hash-endif-directives-c-cpp.md
+++ b/docs/preprocessor/hash-if-hash-elif-hash-else-and-hash-endif-directives-c-cpp.md
@@ -28,7 +28,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 07/27/2020
 ms.locfileid: "87231599"
 ---
-# <a name="if-elif-else-and-endif-directives-cc"></a>#if、#elif、#else、および #endif ディレクティブ (C/c + +)
+# <a name="if-elif-else-and-endif-directives-cc"></a>#if、#elif、#else、および #endif ディレクティブ (C/C++)
 
 **#If**ディレクティブは、 **#elif**、 **#else**、および **#endif**ディレクティブを使用して、ソースファイルの一部のコンパイルを制御します。 ( **#If**の後に) 記述する式が0以外の値を持つ場合、 **#if**ディレクティブの直後の行グループが翻訳単位に保持されます。
 


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/cpp/preprocessor/hash-if-hash-elif-hash-else-and-hash-endif-directives-c-cpp?view=vs-2019

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
